### PR TITLE
feat: add /stack page showing deployed tech

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           context: './${{ env.FRONTEND_PATH }}'
           push: true
+          build-args: PUBLIC_FRONTEND=${{ vars.DIST_FRONTEND }}
           tags: |
             ${{ vars.ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REGISTRY }}/${{ vars.SERVICE_NAME }}:${{ github.sha }}
 

--- a/frontends/svelte/dockerfile
+++ b/frontends/svelte/dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+ARG PUBLIC_FRONTEND
+ENV PUBLIC_FRONTEND=$PUBLIC_FRONTEND
 RUN npm run build
 
 FROM node:20-alpine AS runner

--- a/frontends/svelte/src/lib/components/Navigation.svelte
+++ b/frontends/svelte/src/lib/components/Navigation.svelte
@@ -5,4 +5,5 @@
 <nav id="nav" class="mb-10 flex flex-row justify-center">
 	<NavigationButton href="/" label="ABOUT" />
 	<NavigationButton href="/articles" label="ARTICLES" />
+	<NavigationButton href="/stack" label="STACK" />
 </nav>

--- a/frontends/svelte/src/routes/stack/+page.svelte
+++ b/frontends/svelte/src/routes/stack/+page.svelte
@@ -1,0 +1,28 @@
+<script>
+	import { PUBLIC_FRONTEND } from '$env/static/public';
+
+	const frontendName = PUBLIC_FRONTEND === 'react' ? 'React' : 'SvelteKit';
+
+	const stack = [
+		{ label: 'Frontend', value: frontendName },
+		{ label: 'Hosting', value: 'Google Cloud Run' },
+		{ label: 'Registry', value: 'Google Artifact Registry' },
+		{ label: 'Container', value: 'Docker' }
+	];
+</script>
+
+<svelte:head>
+	<title>Stack</title>
+</svelte:head>
+
+<div class="mx-auto max-w-2xl">
+	<h1 class="mb-8 text-2xl font-bold">Stack</h1>
+	<dl class="divide-y divide-gray-200">
+		{#each stack as { label, value }}
+			<div class="flex py-4">
+				<dt class="w-40 shrink-0 text-gray-500">{label}</dt>
+				<dd>{value}</dd>
+			</div>
+		{/each}
+	</dl>
+</div>


### PR DESCRIPTION
Adds a /stack page linked from the nav showing what is currently deployed.

- PUBLIC_FRONTEND env var baked in at build time (Dockerfile + CI) maps to a display name (SvelteKit / React)
- Infrastructure details (Cloud Run, GCP, Docker) are hardcoded
- Stack nav link added to Navigation component

Closes #38