### PR TITLE
feat: load articles from the Go API in the frontend

### DIFF
--- a/frontends/svelte/src/lib/services/ApiArticleService.ts
+++ b/frontends/svelte/src/lib/services/ApiArticleService.ts
@@ -1,0 +1,28 @@
+import type { IArticle, IArticleDto } from '$lib/types';
+import { mapDtoToArticle } from '$lib/utils/mapDtoToArticle';
+import type { IArticleService } from '$lib/services/IArticleService';
+
+export class ApiArticleService implements IArticleService {
+	constructor(private readonly baseUrl: string) {}
+
+	async getArticles(): Promise<IArticle[]> {
+		const response = await fetch(`${this.baseUrl}/articles`);
+		if (!response.ok) {
+			throw new Error(`Failed to fetch articles: ${response.status}`);
+		}
+		const dtos: IArticleDto[] = await response.json();
+		return dtos.map(mapDtoToArticle);
+	}
+
+	async getArticleById(id: string): Promise<IArticle | null> {
+		const response = await fetch(`${this.baseUrl}/articles/${id}`);
+		if (response.status === 404) {
+			return null;
+		}
+		if (!response.ok) {
+			throw new Error(`Failed to fetch article: ${response.status}`);
+		}
+		const dto: IArticleDto = await response.json();
+		return mapDtoToArticle(dto);
+	}
+}

--- a/frontends/svelte/src/routes/articles/+page.server.ts
+++ b/frontends/svelte/src/routes/articles/+page.server.ts
@@ -1,11 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
-import type { IArticleService } from '$lib/services/IArticleService';
-import { FileArticleService } from '$lib/services/FileArticleService';
+import { env } from '$env/dynamic/private';
+import { ApiArticleService } from '$lib/services/ApiArticleService';
 
 export const load: PageServerLoad = async () => {
 	try {
-		const articleService: IArticleService = new FileArticleService();
+		const articleService = new ApiArticleService(env.API_URL);
 		const articles = await articleService.getArticles();
 
 		return {

--- a/frontends/svelte/src/routes/articles/[id]/+page.server.ts
+++ b/frontends/svelte/src/routes/articles/[id]/+page.server.ts
@@ -1,13 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
-
-import type { IArticleService } from '$lib/services/IArticleService';
-import { FileArticleService } from '$lib/services/FileArticleService';
+import { env } from '$env/dynamic/private';
+import { ApiArticleService } from '$lib/services/ApiArticleService';
 import type { IArticle } from '$lib/types/article';
 
 export const load: PageServerLoad<{ article: IArticle | null }> = async ({ params }) => {
 	try {
-		const articleService: IArticleService = new FileArticleService();
+		const articleService = new ApiArticleService(env.API_URL);
 		const article = await articleService.getArticleById(params.id);
 
 		return {

--- a/frontends/svelte/src/tests/unit/ApiArticleService.test.ts
+++ b/frontends/svelte/src/tests/unit/ApiArticleService.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IArticleDto } from '$lib/types';
+
+import { ApiArticleService } from '$lib/services/ApiArticleService';
+
+const testDtos: IArticleDto[] = [
+	{
+		id: '1',
+		title: 'First Article',
+		summary: 'First summary',
+		body: 'First body',
+		created: '2024-01-01T12:00:00Z',
+		lastModifiedAt: '2024-01-01T12:00:00Z'
+	}
+];
+
+function mockFetch(body: unknown, status = 200) {
+	return vi.spyOn(global, 'fetch').mockResolvedValue(
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { 'Content-Type': 'application/json' }
+		})
+	);
+}
+
+describe('ApiArticleService', () => {
+	let service: ApiArticleService;
+
+	beforeEach(() => {
+		service = new ApiArticleService('http://test-api');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('getArticles', () => {
+		it('fetches from the correct endpoint', async () => {
+			const spy = mockFetch(testDtos);
+			await service.getArticles();
+			expect(spy).toHaveBeenCalledWith('http://test-api/articles');
+		});
+
+		it('returns mapped articles with Date objects', async () => {
+			mockFetch(testDtos);
+			const articles = await service.getArticles();
+			expect(articles).toHaveLength(1);
+			expect(articles[0].created).toBeInstanceOf(Date);
+			expect(articles[0].lastModifiedAt).toBeInstanceOf(Date);
+		});
+
+		it('throws on non-ok response', async () => {
+			mockFetch({}, 500);
+			await expect(service.getArticles()).rejects.toThrow();
+		});
+	});
+
+	describe('getArticleById', () => {
+		it('fetches from the correct endpoint', async () => {
+			const spy = mockFetch(testDtos[0]);
+			await service.getArticleById('1');
+			expect(spy).toHaveBeenCalledWith('http://test-api/articles/1');
+		});
+
+		it('returns a mapped article with Date objects', async () => {
+			mockFetch(testDtos[0]);
+			const article = await service.getArticleById('1');
+			expect(article?.created).toBeInstanceOf(Date);
+			expect(article?.lastModifiedAt).toBeInstanceOf(Date);
+		});
+
+		it('returns null on 404', async () => {
+			mockFetch({}, 404);
+			const article = await service.getArticleById('missing');
+			expect(article).toBeNull();
+		});
+
+		it('throws on other non-ok responses', async () => {
+			mockFetch({}, 500);
+			await expect(service.getArticleById('1')).rejects.toThrow();
+		});
+	});
+});

--- a/frontends/svelte/tsconfig.json
+++ b/frontends/svelte/tsconfig.json
@@ -12,5 +12,4 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"include": ["src/**/*.ts", "src/**/*.svelte", "src/tests/**/*.ts", "src/tests/vitest.d.ts"]
 }


### PR DESCRIPTION
The frontend now fetches article data from the Go API at runtime rather than reading from a bundled JSON file. `ApiArticleService` implements the existing `IArticleService` interface so the swap is transparent to components. `API_URL` is a private server-side env var — never exposed to the browser.

Also fixes a long-standing tsconfig issue where a redundant `include` override was silently blocking all `$env/*` type declarations.

Closes #45