### PR TITLE
refactor: move view count increment out of load into onMount

### DIFF
--- a/frontends/svelte/src/routes/articles/[id]/+page.server.ts
+++ b/frontends/svelte/src/routes/articles/[id]/+page.server.ts
@@ -9,9 +9,8 @@ export const load: PageServerLoad<{ article: IArticle | null; viewCount: number 
 }) => {
 	try {
 		const articleService = new ApiArticleService(env.API_URL);
-		const [article, , viewCountRes] = await Promise.all([
+		const [article, viewCountRes] = await Promise.all([
 			articleService.getArticleById(params.id),
-			fetch(`${env.API_URL}/articles/${params.id}/views`, { method: 'POST' }),
 			fetch(`${env.API_URL}/articles/${params.id}/views`)
 		]);
 

--- a/frontends/svelte/src/routes/articles/[id]/+page.svelte
+++ b/frontends/svelte/src/routes/articles/[id]/+page.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
 	import ArticleDetail from '$lib/components/article/ArticleDetail.svelte';
 	import BackToArticles from '$lib/components/article/BackToArticles.svelte';
 	import type { IArticle } from '$lib/types/article.js';
 
 	let { data }: { data: { article: IArticle | null; viewCount: number } } = $props();
+
+	onMount(() => {
+		fetch(`/articles/${page.params.id}/views`, { method: 'POST' });
+	});
 </script>
 
 <div class="flex flex-col">

--- a/frontends/svelte/src/routes/articles/[id]/views/+server.ts
+++ b/frontends/svelte/src/routes/articles/[id]/views/+server.ts
@@ -1,0 +1,7 @@
+import { env } from '$env/dynamic/private';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ params }) => {
+	await fetch(`${env.API_URL}/articles/${params.id}/views`, { method: 'POST' });
+	return new Response(null, { status: 204 });
+};


### PR DESCRIPTION
Separates the CQS violation where `load` was both querying article data and mutating view count in a single `Promise.all`. The `load` function now makes only GET requests. The increment fires client-side via `onMount`, routed through a new SvelteKit server endpoint (`/articles/[id]/views`) that proxies to the Go API and keeps `API_URL` private.

Closes #53