### PR TITLE
fix: log errors before swallowing them in page load functions

### DIFF
--- a/frontends/svelte/src/routes/articles/+page.server.ts
+++ b/frontends/svelte/src/routes/articles/+page.server.ts
@@ -11,7 +11,8 @@ export const load: PageServerLoad = async () => {
 		return {
 			articles
 		};
-	} catch {
+	} catch (e) {
+		console.error('Failed to load articles:', e);
 		error(500, 'Failed to load articles');
 	}
 };

--- a/frontends/svelte/src/routes/articles/[id]/+page.server.ts
+++ b/frontends/svelte/src/routes/articles/[id]/+page.server.ts
@@ -15,12 +15,17 @@ export const load: PageServerLoad<{ article: IArticle | null; viewCount: number 
 			fetch(`${env.API_URL}/articles/${params.id}/views`)
 		]);
 
+		if (!viewCountRes.ok) {
+			console.warn(`View count API returned ${viewCountRes.status} for article ${params.id}`);
+		}
+
 		const viewCount: number = viewCountRes.ok
 			? ((await viewCountRes.json()) as { viewCount: number }).viewCount
 			: 0;
 
 		return { article, viewCount };
-	} catch {
+	} catch (e) {
+		console.error('Failed to load article:', e);
 		error(500, 'Failed to load article');
 	}
 };


### PR DESCRIPTION
Caught exceptions in both page server load functions now log the root cause before returning a generic 500, making failures visible in production. The view count fallback also logs a warning with the HTTP status when the API returns a non-OK response, so a real 0 is distinguishable from an API failure.

Closes #54