### PR TITLE
fix: propagate DataAt and unexpected-type errors from GetViewCount

### DIFF
--- a/backends/apis/go/cmd/api/firestore.go
+++ b/backends/apis/go/cmd/api/firestore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"cloud.google.com/go/firestore"
 	"google.golang.org/grpc/codes"
@@ -39,7 +40,7 @@ func (s *firestoreViewStore) GetViewCount(ctx context.Context, articleID string)
 	}
 	count, err := doc.DataAt("count")
 	if err != nil {
-		return 0, nil
+		return 0, fmt.Errorf("reading count field: %w", err)
 	}
 	switch v := count.(type) {
 	case int64:
@@ -47,6 +48,6 @@ func (s *firestoreViewStore) GetViewCount(ctx context.Context, articleID string)
 	case float64:
 		return int64(v), nil
 	default:
-		return 0, nil
+		return 0, fmt.Errorf("unexpected type for count field: %T", v)
 	}
 }


### PR DESCRIPTION
`GetViewCount` was silently returning `(0, nil)` for two cases that should be errors: a `DataAt` failure (field missing or wrong key) and an unrecognised Firestore field type. These now return wrapped errors so callers can distinguish corrupted or missing data from a legitimate zero view count.

Closes #55