### PR TITLE
refactor: remove duplicated dead-code validation from FileArticleService

### DIFF
--- a/frontends/svelte/src/lib/services/FileArticleService.ts
+++ b/frontends/svelte/src/lib/services/FileArticleService.ts
@@ -8,18 +8,10 @@ const articlesData = rawArticles as { articles: IArticleDto[] };
 
 export class FileArticleService implements IArticleService {
 	async getArticles(): Promise<IArticle[]> {
-		if (!articlesData.articles || !Array.isArray(articlesData.articles)) {
-			throw new Error('Invalid articles data format');
-		}
-
 		return articlesData.articles.map(mapDtoToArticle);
 	}
 
 	async getArticleById(id: string): Promise<IArticle | null> {
-		if (!articlesData.articles || !Array.isArray(articlesData.articles)) {
-			throw new Error('Invalid articles data format');
-		}
-
 		const articleDto = articlesData.articles.find((article) => article.id === id);
 		return articleDto ? mapDtoToArticle(articleDto) : null;
 	}


### PR DESCRIPTION
Both methods in `FileArticleService` contained the same array guard that could never trigger — the articles data is a static JSON import cast at compile time, so TypeScript verifies the shape and the bundler rejects malformed JSON. Removing the duplicate dead-code blocks leaves both methods clean with no behaviour change for callers.

Closes #56