### PR TITLE
refactor: extract shared figure HTML builder in ArticleDetail

### DIFF
--- a/frontends/svelte/src/lib/components/article/ArticleDetail.svelte
+++ b/frontends/svelte/src/lib/components/article/ArticleDetail.svelte
@@ -14,20 +14,19 @@
 		});
 
 	const showUpdated = () => article.lastModifiedAt !== article.created;
+
+	const buildFigureHtml = (href: string, text: string) =>
+		`<figure class="prose-figure"><img src="${href}" alt="${text}"><figcaption>${text}</figcaption></figure>`;
+
 	marked.use({
 		renderer: {
 			image({ href, text }: { href: string; text: string }) {
-				return `<figure class="prose-figure"><img src="${href}" alt="${text}"><figcaption>${text}</figcaption></figure>`;
+				return buildFigureHtml(href, text);
 			},
 			paragraph({ tokens }: { tokens: { type: string; href?: string; text?: string }[] }) {
 				const meaningful = tokens.filter((t) => !(t.type === 'text' && !t.text?.trim()));
 				if (!meaningful.length || !meaningful.every((t) => t.type === 'image')) return false;
-				const figures = meaningful
-					.map(
-						(t) =>
-							`<figure class="prose-figure"><img src="${t.href}" alt="${t.text}"><figcaption>${t.text}</figcaption></figure>`
-					)
-					.join('');
+				const figures = meaningful.map((t) => buildFigureHtml(t.href!, t.text!)).join('');
 				return meaningful.length > 1 ? `<div class="image-row">${figures}</div>` : figures;
 			}
 		}


### PR DESCRIPTION
The figure HTML template was duplicated verbatim between the `image` and `paragraph` marked renderers — any change to the figure structure (CSS class, wrapper element, accessibility attribute) required touching both. Extracting `buildFigureHtml` means the structure lives in exactly one place.

Closes #57