### PR TITLE
refactor: extract route registration from main() in Go API

### DIFF
--- a/backends/apis/go/cmd/api/main.go
+++ b/backends/apis/go/cmd/api/main.go
@@ -10,6 +10,13 @@ import (
 	"harry.willis.dev/go/articles/internal/service"
 )
 
+func registerRoutes(mux *http.ServeMux, srv *server) {
+	mux.HandleFunc("GET /articles", srv.handleGetArticles)
+	mux.HandleFunc("GET /articles/{id}", srv.handleGetArticleByID)
+	mux.HandleFunc("POST /articles/{id}/views", srv.handleIncrementViewCount)
+	mux.HandleFunc("GET /articles/{id}/views", srv.handleGetViewCount)
+}
+
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
@@ -28,10 +35,7 @@ func main() {
 	srv := &server{articles: svc, views: views}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /articles", srv.handleGetArticles)
-	mux.HandleFunc("GET /articles/{id}", srv.handleGetArticleByID)
-	mux.HandleFunc("POST /articles/{id}/views", srv.handleIncrementViewCount)
-	mux.HandleFunc("GET /articles/{id}/views", srv.handleGetViewCount)
+	registerRoutes(mux, srv)
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
`main()` was doing too much — logging setup, two service initialisations, route registration, and server startup were all inlined. Extracting `registerRoutes(mux, srv)` gives `main()` a clean high-level structure (init → register → serve) and makes it easy to add or remove endpoints without navigating startup logic.

Closes #58