### PR TITLE
fix: make React navigation a landmark region for screen readers

### DIFF
--- a/frontends/react/src/components/navigation/navigation.tsx
+++ b/frontends/react/src/components/navigation/navigation.tsx
@@ -4,9 +4,9 @@ import { NavigationButton } from ".";
 
 export const Navigation: React.FC = () => {
 	return (
-		<div id="nav" className="flex flex-row justify-center mb-10">
+		<nav id="nav" className="flex flex-row justify-center mb-10">
 			<NavigationButton href="/" label="ABOUT" />
 			<NavigationButton href="/articles" label="ARTICLES" />
-		</div>
+		</nav>
 	);
 };


### PR DESCRIPTION
Replaces the `<div>` wrapper in the React `Navigation` component with a `<nav>` element, exposing a navigation landmark that screen readers can announce and users can jump to directly.

Closes #64