### PR TITLE
fix: move lang attribute to html element so screen readers detect page language

### DIFF
--- a/frontends/react/public/index.html
+++ b/frontends/react/public/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
-<html>
-	<head lang="en">
+<html lang="en">
+	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
Moves `lang="en"` from the invalid `<head>` element to `<html>`, so screen readers, browsers, and translation tools can correctly determine the document language. The `lang` attribute on `<head>` is ignored by all user agents.

Closes #66