### PR TITLE
fix: use section element so aria-label is honoured by screen readers

### DIFF
--- a/frontends/react/src/components/article/articleList.tsx
+++ b/frontends/react/src/components/article/articleList.tsx
@@ -11,18 +11,18 @@ interface IArticleListProps {
 export const ArticleList: React.FC<IArticleListProps> = ({ articles }) => {
 	if (articles.length === 0) {
 		return (
-			<div className="border-t border-gray-200 pt-6" data-testid="article-list-empty" aria-label="Article List">
+			<section className="border-t border-gray-200 pt-6" data-testid="article-list-empty" aria-label="Article List">
 				<p className="text-sm text-gray-400 italic font-serif">No articles yet — check back soon.</p>
-			</div>
+			</section>
 		);
 	}
 
 	return (
-		<div className="flex flex-col border-t border-gray-200" data-testid="article-list" aria-label="Article List">
+		<section className="flex flex-col border-t border-gray-200" data-testid="article-list" aria-label="Article List">
 			{articles.map((article, index) => (
 				<ArticleListItem key={article.id} article={article} index={index} />
 			))}
 			<Footer />
-		</div>
+		</section>
 	);
 };

--- a/frontends/react/src/pages/aboutPage.tsx
+++ b/frontends/react/src/pages/aboutPage.tsx
@@ -4,7 +4,7 @@ import { Footer } from "src/components/footer";
 
 export const AboutPage: React.FC = () => {
 	return (
-		<div className="flex flex-col" data-testid="about-page" aria-label="About Page">
+		<section className="flex flex-col" data-testid="about-page" aria-label="About Page">
 			<div className="border-t border-gray-200 pt-6">
 				<h1 className="font-serif text-3xl font-semibold text-gray-900 mb-4 leading-snug">Hello</h1>
 				<p className="text-sm text-gray-500 leading-relaxed mb-4">
@@ -19,6 +19,6 @@ export const AboutPage: React.FC = () => {
 				</p>
 			</div>
 			<Footer />
-		</div>
+		</section>
 	);
 };

--- a/frontends/svelte/src/lib/components/article/ArticleList.svelte
+++ b/frontends/svelte/src/lib/components/article/ArticleList.svelte
@@ -7,14 +7,14 @@
 </script>
 
 {#if articles.length === 0}
-	<div class="border-t border-gray-200 pt-6" aria-label="Article List">
+	<section class="border-t border-gray-200 pt-6" aria-label="Article List">
 		<p class="font-serif text-sm text-gray-400 italic">No articles yet — check back soon.</p>
-	</div>
+	</section>
 {:else}
-	<div class="flex flex-col border-t border-gray-200" aria-label="Article List">
+	<section class="flex flex-col border-t border-gray-200" aria-label="Article List">
 		{#each articles as article, index (article.id)}
 			<ArticleListItem {article} {index} />
 		{/each}
-	</div>
+	</section>
 {/if}
 <Footer />


### PR DESCRIPTION
Replaces `<div aria-label="...">` with `<section aria-label="...">` in the article list and about page across both React and Svelte frontends. Browsers only expose `aria-label` as an accessible name on elements with a role — `<section>` gains `role="region"` automatically when given an accessible name, making these page regions navigable landmarks for screen reader users.

Closes #67