### PR TITLE
fix: announce to screen readers when footer links open in a new tab

### DIFF
--- a/frontends/react/src/__tests__/components/article/articleList.test.tsx
+++ b/frontends/react/src/__tests__/components/article/articleList.test.tsx
@@ -63,7 +63,7 @@ describe(ArticleList, () => {
 	test("renders Footer component", () => {
 		render(<ArticleList articles={mockArticles} />);
 
-		const githubLink = screen.getByRole("link", { name: "github" });
+		const githubLink = screen.getByRole("link", { name: "github (opens in new tab)" });
 		expect(githubLink).toBeInTheDocument();
 	});
 

--- a/frontends/react/src/__tests__/components/footer.test.tsx
+++ b/frontends/react/src/__tests__/components/footer.test.tsx
@@ -8,7 +8,7 @@ describe(Footer, () => {
 	test("renders GitHub icon link with correct attributes", () => {
 		render(<Footer />);
 
-		const githubLink = screen.getByRole("link", { name: "github" });
+		const githubLink = screen.getByRole("link", { name: "github (opens in new tab)" });
 
 		expect(githubLink).toHaveAttribute("href", "https://github.com/HarryWillis0");
 		expect(githubLink).toHaveAttribute("target", "_blank");
@@ -18,7 +18,7 @@ describe(Footer, () => {
 	test("renders Strava icon link with correct attributes", () => {
 		render(<Footer />);
 
-		const stravaLink = screen.getByRole("link", { name: "strava" });
+		const stravaLink = screen.getByRole("link", { name: "strava (opens in new tab)" });
 
 		expect(stravaLink).toHaveAttribute("href", "https://www.strava.com/athletes/17003155");
 		expect(stravaLink).toHaveAttribute("target", "_blank");
@@ -28,7 +28,7 @@ describe(Footer, () => {
 	test("renders GitHub icon link", () => {
 		render(<Footer />);
 
-		const githubIcon = screen.getByRole("link", { name: "github" }).querySelector("i");
+		const githubIcon = screen.getByRole("link", { name: "github (opens in new tab)" }).querySelector("i");
 
 		expect(githubIcon).toHaveClass("fa-brands", "fa-github");
 	});
@@ -36,7 +36,7 @@ describe(Footer, () => {
 	test("renders Strava icon link", () => {
 		render(<Footer />);
 
-		const stravaIcon = screen.getByRole("link", { name: "strava" }).querySelector("i");
+		const stravaIcon = screen.getByRole("link", { name: "strava (opens in new tab)" }).querySelector("i");
 
 		expect(stravaIcon).toHaveClass("fab", "fa-strava");
 	});

--- a/frontends/react/src/__tests__/pages/aboutPage.test.tsx
+++ b/frontends/react/src/__tests__/pages/aboutPage.test.tsx
@@ -17,7 +17,7 @@ describe(AboutPage, () => {
 		expect(screen.getByText(/Hello/i)).toBeInTheDocument();
 		expect(screen.getByText(/full stack developer/i)).toBeInTheDocument();
 		expect(screen.getByText(/traditional territories of the peoples of Treaty 7/i)).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "github" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "github (opens in new tab)" })).toBeInTheDocument();
 	});
 
 	test("applies correct CSS classes", () => {

--- a/frontends/react/src/components/footer.tsx
+++ b/frontends/react/src/components/footer.tsx
@@ -8,7 +8,7 @@ export const Footer: React.FC = () => {
 				target="_blank"
 				rel="noopener noreferrer"
 				className="icon-button text-4xl mx-5"
-				aria-label="github"
+				aria-label="github (opens in new tab)"
 			>
 				<i className="fa-brands fa-github"></i>
 			</a>
@@ -17,7 +17,7 @@ export const Footer: React.FC = () => {
 				target="_blank"
 				rel="noopener noreferrer"
 				className="icon-button text-4xl mx-5"
-				aria-label="strava"
+				aria-label="strava (opens in new tab)"
 			>
 				<i className="fab fa-strava" />
 			</a>

--- a/frontends/svelte/src/lib/components/Footer.svelte
+++ b/frontends/svelte/src/lib/components/Footer.svelte
@@ -4,7 +4,7 @@
 		target="_blank"
 		rel="noopener noreferrer"
 		class="icon-button mx-5 text-4xl"
-		aria-label="github"
+		aria-label="github (opens in new tab)"
 	>
 		<i class="fa-brands fa-github"></i>
 	</a>
@@ -13,7 +13,7 @@
 		target="_blank"
 		rel="noopener noreferrer"
 		class="icon-button mx-5 text-4xl"
-		aria-label="strava"
+		aria-label="strava (opens in new tab)"
 	>
 		<i class="fab fa-strava"></i>
 	</a>


### PR DESCRIPTION
Appends "(opens in new tab)" to the `aria-label` on the GitHub and Strava footer links in both React and Svelte frontends. Screen reader users are now warned before activating these links that they will be taken to a new browser context, preventing unexpected context switches.

Closes #68