### PR TITLE
fix: give each Svelte route a descriptive page title

### DIFF
--- a/frontends/svelte/src/routes/+page.svelte
+++ b/frontends/svelte/src/routes/+page.svelte
@@ -2,6 +2,10 @@
 	import Footer from '$lib/components/Footer.svelte';
 </script>
 
+<svelte:head>
+	<title>About — harrywillis.dev</title>
+</svelte:head>
+
 <div class="flex flex-col">
 	<div class="border-t border-gray-200 pt-6">
 		<h1 class="mb-4 font-serif text-3xl leading-snug font-semibold text-gray-900">Hello</h1>

--- a/frontends/svelte/src/routes/articles/+page.svelte
+++ b/frontends/svelte/src/routes/articles/+page.svelte
@@ -5,6 +5,10 @@
 	let { data }: { data: { articles: IArticle[] } } = $props();
 </script>
 
+<svelte:head>
+	<title>Articles — harrywillis.dev</title>
+</svelte:head>
+
 <div class="mx-auto max-w-200 flex-1">
 	<ArticleList articles={data.articles} />
 </div>

--- a/frontends/svelte/src/routes/articles/[id]/+page.svelte
+++ b/frontends/svelte/src/routes/articles/[id]/+page.svelte
@@ -12,6 +12,10 @@
 	});
 </script>
 
+<svelte:head>
+	<title>{data.article?.title ?? 'Article'} — harrywillis.dev</title>
+</svelte:head>
+
 <div class="flex flex-col">
 	{#if data.article}
 		<ArticleDetail article={data.article} viewCount={data.viewCount} />


### PR DESCRIPTION
Adds svelte:head title to all three Svelte routes. Screen reader users now hear the page title announced on navigation, and sighted users see a meaningful browser tab label. The article detail page uses the article title so each article is individually identifiable.

Closes #69