### PR TITLE
feat: let visitors browse a list of side projects

### DIFF
--- a/frontends/svelte/src/lib/components/Navigation.svelte
+++ b/frontends/svelte/src/lib/components/Navigation.svelte
@@ -5,4 +5,5 @@
 <nav id="nav" class="mb-10 flex flex-row justify-center">
 	<NavigationButton href="/" label="ABOUT" />
 	<NavigationButton href="/articles" label="ARTICLES" />
+	<NavigationButton href="/projects" label="PROJECTS" />
 </nav>

--- a/frontends/svelte/src/lib/components/project/BackToProjects.svelte
+++ b/frontends/svelte/src/lib/components/project/BackToProjects.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+</script>
+
+<div class="mt-8 border-t border-gray-100 pt-6">
+	<a
+		href={resolve('/projects')}
+		class="tracking-widests text-xs text-gray-300 uppercase no-underline transition-colors duration-200 hover:text-gray-900"
+	>
+		← All projects
+	</a>
+</div>

--- a/frontends/svelte/src/lib/components/project/ProjectDetail.svelte
+++ b/frontends/svelte/src/lib/components/project/ProjectDetail.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { marked } from 'marked';
+	import type { IProject } from '$lib/types';
+
+	let { project }: { project: IProject } = $props();
+
+	const renderedBody = () => marked(project.body);
+</script>
+
+<!-- Header -->
+<div class="mb-8 border-t border-gray-200 pt-6">
+	<h1 class="mb-3 font-serif text-3xl leading-snug font-semibold text-gray-900">{project.title}</h1>
+	<p class="mb-3 font-serif text-sm text-gray-400 italic">{project.description}</p>
+	<div class="mb-4 flex flex-wrap gap-4 text-xs tracking-widest text-gray-300 uppercase">
+		{#each project.tags as tag (tag)}
+			<span>{tag}</span>
+		{/each}
+	</div>
+	<div class="flex gap-4 text-xs tracking-widest uppercase">
+		<a
+			href={project.repoUrl}
+			target="_blank"
+			rel="noopener noreferrer external"
+			class="text-gray-400 no-underline hover:text-gray-900">Repo</a
+		>
+		{#if project.liveUrl}
+			<a
+				href={project.liveUrl}
+				target="_blank"
+				rel="noopener noreferrer external"
+				class="text-gray-400 no-underline hover:text-gray-900">Live</a
+			>
+		{/if}
+	</div>
+</div>
+
+<!-- Body -->
+<div class="prose-custom">
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html renderedBody()}
+</div>

--- a/frontends/svelte/src/lib/components/project/ProjectList.svelte
+++ b/frontends/svelte/src/lib/components/project/ProjectList.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import Footer from '$lib/components/Footer.svelte';
+	import ProjectListItem from '$lib/components/project/ProjectListItem.svelte';
+	import { type IProject } from '$lib/types';
+
+	let { projects }: { projects: IProject[] } = $props();
+</script>
+
+{#if projects.length === 0}
+	<section class="border-t border-gray-200 pt-6" aria-label="Project List">
+		<p class="font-serif text-sm text-gray-400 italic">No projects yet — check back soon.</p>
+	</section>
+{:else}
+	<section class="flex flex-col border-t border-gray-200" aria-label="Project List">
+		{#each projects as project (project.id)}
+			<ProjectListItem {project} />
+		{/each}
+	</section>
+{/if}
+<Footer />

--- a/frontends/svelte/src/lib/components/project/ProjectListItem.svelte
+++ b/frontends/svelte/src/lib/components/project/ProjectListItem.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { IProject } from '$lib/types';
+
+	let { project }: { project: IProject } = $props();
+</script>
+
+<!-- eslint-disable svelte/no-navigation-without-resolve -- /projects/[id] route lands in #79 -->
+<a
+	href={`/projects/${project.id}`}
+	class="group flex flex-col gap-1.5 border-b border-gray-100 py-6 text-inherit no-underline transition-colors duration-200 hover:bg-gray-50"
+>
+	<h2 class="font-serif text-lg leading-snug font-semibold text-gray-900 group-hover:underline">
+		{project.title}
+	</h2>
+	<p class="line-clamp-2 text-sm leading-relaxed text-gray-500">{project.description}</p>
+	<div class="mt-1 flex flex-wrap gap-2">
+		{#each project.tags as tag (tag)}
+			<span class="text-xs tracking-widest text-gray-300 uppercase">{tag}</span>
+		{/each}
+	</div>
+</a>
+<!-- eslint-enable svelte/no-navigation-without-resolve -->

--- a/frontends/svelte/src/lib/components/project/ProjectListItem.svelte
+++ b/frontends/svelte/src/lib/components/project/ProjectListItem.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { IProject } from '$lib/types';
 
 	let { project }: { project: IProject } = $props();
 </script>
 
-<!-- eslint-disable svelte/no-navigation-without-resolve -- /projects/[id] route lands in #79 -->
 <a
-	href={`/projects/${project.id}`}
+	href={resolve(`/projects/${project.id}`)}
 	class="group flex flex-col gap-1.5 border-b border-gray-100 py-6 text-inherit no-underline transition-colors duration-200 hover:bg-gray-50"
 >
 	<h2 class="font-serif text-lg leading-snug font-semibold text-gray-900 group-hover:underline">
@@ -19,4 +19,3 @@
 		{/each}
 	</div>
 </a>
-<!-- eslint-enable svelte/no-navigation-without-resolve -->

--- a/frontends/svelte/src/lib/data/projects.ts
+++ b/frontends/svelte/src/lib/data/projects.ts
@@ -1,0 +1,3 @@
+import type { IProject } from '$lib/types';
+
+export const projects: IProject[] = [];

--- a/frontends/svelte/src/lib/types/index.ts
+++ b/frontends/svelte/src/lib/types/index.ts
@@ -1,2 +1,3 @@
 export * from './article';
 export * from './api';
+export * from './project';

--- a/frontends/svelte/src/lib/types/project.ts
+++ b/frontends/svelte/src/lib/types/project.ts
@@ -1,0 +1,9 @@
+export interface IProject {
+	id: string;
+	title: string;
+	description: string;
+	body: string;
+	tags: string[];
+	repoUrl: string;
+	liveUrl?: string;
+}

--- a/frontends/svelte/src/routes/projects/+page.svelte
+++ b/frontends/svelte/src/routes/projects/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import ProjectList from '$lib/components/project/ProjectList.svelte';
+	import { projects } from '$lib/data/projects';
+</script>
+
+<svelte:head>
+	<title>Projects — harrywillis.dev</title>
+</svelte:head>
+
+<div class="mx-auto max-w-200 flex-1">
+	<ProjectList {projects} />
+</div>

--- a/frontends/svelte/src/routes/projects/[id]/+page.svelte
+++ b/frontends/svelte/src/routes/projects/[id]/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import ProjectDetail from '$lib/components/project/ProjectDetail.svelte';
+	import BackToProjects from '$lib/components/project/BackToProjects.svelte';
+	import type { IProject } from '$lib/types';
+
+	let { data }: { data: { project: IProject | null } } = $props();
+</script>
+
+<svelte:head>
+	<title>{data.project?.title ?? 'Project'} — harrywillis.dev</title>
+</svelte:head>
+
+<div class="flex flex-col">
+	{#if data.project}
+		<ProjectDetail project={data.project} />
+	{:else}
+		<div class="border-t border-gray-200 pt-6">
+			<h1 class="mb-4 font-serif text-3xl leading-snug font-semibold text-gray-900">
+				Project not found
+			</h1>
+			<p class="text-sm leading-relaxed text-gray-500">
+				The project you are looking for does not exist.
+			</p>
+		</div>
+	{/if}
+	<BackToProjects />
+</div>

--- a/frontends/svelte/src/routes/projects/[id]/+page.ts
+++ b/frontends/svelte/src/routes/projects/[id]/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types';
+import { projects } from '$lib/data/projects';
+import type { IProject } from '$lib/types';
+
+export const load: PageLoad<{ project: IProject | null }> = ({ params }) => {
+	const project = projects.find((p) => p.id === params.id) ?? null;
+
+	return { project };
+};

--- a/frontends/svelte/src/tests/components/ProjectDetail.test.ts
+++ b/frontends/svelte/src/tests/components/ProjectDetail.test.ts
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+
+import ProjectDetail from '$lib/components/project/ProjectDetail.svelte';
+import ProjectPage from '../../routes/projects/[id]/+page.svelte';
+import type { IProject } from '$lib/types';
+
+const mockProject: IProject = {
+	id: 'test-project',
+	title: 'Test Project',
+	description: 'A short blurb about the project',
+	body: 'Some **markdown** body',
+	tags: ['Svelte', 'TypeScript'],
+	repoUrl: 'https://github.com/harrywillis0/test-project'
+};
+
+const mockProjectWithLive: IProject = {
+	...mockProject,
+	id: 'live-project',
+	liveUrl: 'https://live-project.example.com'
+};
+
+describe('ProjectDetail', () => {
+	it('renders title, description, and tags', () => {
+		render(ProjectDetail, { props: { project: mockProject } });
+		expect(screen.getByText('Test Project')).toBeInTheDocument();
+		expect(screen.getByText('A short blurb about the project')).toBeInTheDocument();
+		expect(screen.getByText('Svelte')).toBeInTheDocument();
+		expect(screen.getByText('TypeScript')).toBeInTheDocument();
+	});
+
+	it('renders the markdown body', () => {
+		render(ProjectDetail, { props: { project: mockProject } });
+		const strong = screen.getByText('markdown');
+		expect(strong.tagName).toBe('STRONG');
+	});
+
+	it('renders a Repo link with target=_blank and rel=noopener noreferrer', () => {
+		render(ProjectDetail, { props: { project: mockProject } });
+		const link = screen.getByRole('link', { name: 'Repo' });
+		expect(link).toHaveAttribute('href', mockProject.repoUrl);
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link.getAttribute('rel')?.split(/\s+/)).toEqual(
+			expect.arrayContaining(['noopener', 'noreferrer'])
+		);
+	});
+
+	it('does not render a Live link when liveUrl is absent', () => {
+		render(ProjectDetail, { props: { project: mockProject } });
+		expect(screen.queryByRole('link', { name: 'Live' })).not.toBeInTheDocument();
+	});
+
+	it('renders a Live link with target=_blank and rel=noopener noreferrer when liveUrl is present', () => {
+		render(ProjectDetail, { props: { project: mockProjectWithLive } });
+		const link = screen.getByRole('link', { name: 'Live' });
+		expect(link).toHaveAttribute('href', mockProjectWithLive.liveUrl);
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link.getAttribute('rel')?.split(/\s+/)).toEqual(
+			expect.arrayContaining(['noopener', 'noreferrer'])
+		);
+	});
+});
+
+describe('/projects/[id] page', () => {
+	it('renders ProjectDetail when the project is found', () => {
+		render(ProjectPage, { props: { data: { project: mockProject } } });
+		expect(screen.getByText('Test Project')).toBeInTheDocument();
+	});
+
+	it('shows an inline not-found message when the project is missing', () => {
+		render(ProjectPage, { props: { data: { project: null } } });
+		expect(screen.getByText('Project not found')).toBeInTheDocument();
+	});
+
+	it('links back to /projects from the not-found state', () => {
+		render(ProjectPage, { props: { data: { project: null } } });
+		const link = screen.getByRole('link', { name: /all projects/i });
+		expect(link).toHaveAttribute('href', '/projects');
+	});
+});

--- a/frontends/svelte/src/tests/components/ProjectList.test.ts
+++ b/frontends/svelte/src/tests/components/ProjectList.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+
+import ProjectList from '$lib/components/project/ProjectList.svelte';
+import type { IProject } from '$lib/types';
+
+const mockProjects: IProject[] = [
+	{
+		id: 'first-project',
+		title: 'First Project',
+		description: 'First description',
+		body: 'First body',
+		tags: ['Go'],
+		repoUrl: 'https://github.com/harrywillis0/first-project'
+	},
+	{
+		id: 'second-project',
+		title: 'Second Project',
+		description: 'Second description',
+		body: 'Second body',
+		tags: ['React'],
+		repoUrl: 'https://github.com/harrywillis0/second-project',
+		liveUrl: 'https://second-project.example.com'
+	}
+];
+
+describe('ProjectList', () => {
+	it('renders empty state when no projects', () => {
+		render(ProjectList, { props: { projects: [] } });
+
+		expect(screen.getByText('No projects yet — check back soon.')).toBeInTheDocument();
+	});
+
+	it('renders a list when projects are provided', () => {
+		render(ProjectList, { props: { projects: mockProjects } });
+
+		expect(screen.getByText('First Project')).toBeInTheDocument();
+		expect(screen.getByText('Second Project')).toBeInTheDocument();
+	});
+
+	it('renders the correct number of projects', () => {
+		render(ProjectList, { props: { projects: mockProjects } });
+
+		const links = screen.getAllByRole('link');
+		const filteredLinks = links.filter((link) => link.getAttribute('href')?.includes('/projects/'));
+
+		expect(filteredLinks).toHaveLength(mockProjects.length);
+	});
+
+	it('renders footer when projects are present', () => {
+		render(ProjectList, { props: { projects: mockProjects } });
+
+		expect(screen.getByLabelText('Footer')).toBeInTheDocument();
+	});
+});

--- a/frontends/svelte/src/tests/components/ProjectListItem.test.ts
+++ b/frontends/svelte/src/tests/components/ProjectListItem.test.ts
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+
+import ProjectListItem from '$lib/components/project/ProjectListItem.svelte';
+import type { IProject } from '$lib/types';
+
+const mockProject: IProject = {
+	id: 'test-project',
+	title: 'Test Project',
+	description: 'A short blurb about the project',
+	body: 'Full write-up body',
+	tags: ['Svelte', 'TypeScript'],
+	repoUrl: 'https://github.com/harrywillis0/test-project'
+};
+
+describe('ProjectListItem', () => {
+	it('renders project title and description', () => {
+		render(ProjectListItem, { props: { project: mockProject } });
+		expect(screen.getByText('Test Project')).toBeInTheDocument();
+		expect(screen.getByText('A short blurb about the project')).toBeInTheDocument();
+	});
+
+	it('renders each tag', () => {
+		render(ProjectListItem, { props: { project: mockProject } });
+		expect(screen.getByText('Svelte')).toBeInTheDocument();
+		expect(screen.getByText('TypeScript')).toBeInTheDocument();
+	});
+
+	it('links to the correct project page', () => {
+		render(ProjectListItem, { props: { project: mockProject } });
+		const link = screen.getByRole('link');
+		expect(link).toHaveAttribute('href', '/projects/test-project');
+	});
+
+	it('renders no nested links', () => {
+		render(ProjectListItem, { props: { project: mockProject } });
+		const links = screen.getAllByRole('link');
+		expect(links).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Adds a /projects route with a PROJECTS nav link, backed by a static IProject array. The list starts empty and will be populated by hand as projects ship.

Closes #78